### PR TITLE
fix compile for Qt < 5.14 and cmake >= 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.12)
 
 project(fdt-viewer VERSION 0.8.0 LANGUAGES CXX)
 

--- a/src/fdt-view.cpp
+++ b/src/fdt-view.cpp
@@ -71,7 +71,7 @@ string present(const qt_fdt_property &property) {
     }
 
     if (std::count_if(data.begin(), data.end(), [](auto &&value) { return value == 0x00; }) == 1 &&
-        data.back() == 0x00) return result_str({property.data});
+        data.at(data.size() - 1) == 0x00) return result_str({property.data});
 
     return result(present_u32be(property.data));
 }


### PR DESCRIPTION
`QFileDialog::saveFileContent` was implemented since Qt 5.14

I copy-pasted body of this function from original Qt sources.

There is no reason to block compilation on Qt early then 5.14. Tested with Ubuntu 20.04 + Qt 5.12 and it's works fine.