### PR TITLE
Fix multi-line compatible parsing

### DIFF
--- a/src/fdt/fdt-property-types.hpp
+++ b/src/fdt/fdt-property-types.hpp
@@ -26,7 +26,7 @@ struct property_info {
 };
 
 const static QHash<string, property_info> property_map = {
-    {"compatible", {property_type::string, word_size::custom}},
+    {"compatible", {property_type::multiline, word_size::custom}},
     {"phandle", {property_type::number, word_size::_32}},
     {"pinctrl-names", {property_type::multiline, word_size::custom}},
 };


### PR DESCRIPTION
The compatible field is the same as the *-names fields and may contain more than one value separated by nulls.